### PR TITLE
Integrate Clavata into the Clean up Script

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,7 +1,8 @@
 import { setGlobalDispatcher, Agent as Agent } from "undici";
-setGlobalDispatcher(new Agent({ connect: { timeout: 20_000 } }));
 import { BSKY_HANDLE, BSKY_PASSWORD, OZONE_PDS } from "./config.js";
 import { AtpAgent } from "@atproto/api";
+
+setGlobalDispatcher(new Agent({ connect: { timeout: 20_000 } }));
 
 export const agent = new AtpAgent({
     service: `https://${OZONE_PDS}`,

--- a/src/clavataPolicy.ts
+++ b/src/clavataPolicy.ts
@@ -1,0 +1,172 @@
+// clavataPolicy.ts
+import { logger } from "./logger.js";
+
+// This module calls the Clavata Create‑Jobs API and extracts matched labels.
+// API docs: https://api.docs.clavata.net/#tag/Create-Jobs
+
+// JWT token for Clavata API access
+const CLAVATA_AUTH_TOKEN = process.env.CLAVATA_AUTH_TOKEN ?? "";
+// The fixed policy ID to use found in the Clavata policy dashboard
+const POLICY_ID = process.env.POLICY_ID ?? "";
+// Base endpoint for the Clavata Create‑Jobs API (adjust if necessary)
+const CLAVATA_ENDPOINT = "https://gateway.app.clavata.ai:8443/v1/jobs";
+
+/** Possible outcomes from a section evaluation */
+export type Outcome =
+  | "OUTCOME_UNSPECIFIED"
+  | "OUTCOME_TRUE"
+  | "OUTCOME_FALSE"
+  | "OUTCOME_FAILED";
+
+/** Represents a section report returned in a job result */
+export interface SectionReport {
+  name: string;
+  message: string;
+  result: Outcome;
+}
+
+/** Represents a policy report returned for a content item */
+export interface Report {
+  result: Outcome;
+  sectionEvaluationReports: SectionReport[];
+}
+
+/** A result for a single submitted content item */
+export interface Result {
+  report: Report;
+}
+
+/** A Job as returned by Clavata */
+export interface Job {
+  status:
+    | "JOB_STATUS_UNSPECIFIED"
+    | "JOB_STATUS_PENDING"
+    | "JOB_STATUS_RUNNING"
+    | "JOB_STATUS_COMPLETED"
+    | "JOB_STATUS_FAILED"
+    | "JOB_STATUS_CANCELED";
+  results: Result[];
+  created: string; // ISO date string
+  updated: string; // ISO date string
+  completed: string; // ISO date string
+}
+
+/** The response structure from Clavata Create‑Job API */
+export interface CreateJobResponse {
+  job: Job;
+}
+
+/** The content data to send for evaluation */
+export interface ContentData {
+  text: string;
+}
+
+/** The payload for a job request */
+export interface JobRequest {
+  content_data: ContentData[];
+  policy_id: string;
+  wait_for_completion: boolean;
+}
+
+/**
+ * Sends the provided text to the Clavata Create‑Jobs API.
+ *
+ * @param text - The text content to evaluate.
+ * @returns A Promise resolving to the Job returned by Clavata.
+ * @throws An error if the API call fails.
+ */
+export async function createJob(text: string): Promise<Job> {
+  const payload: JobRequest = {
+    content_data: [{ text }],
+    policy_id: POLICY_ID,
+    wait_for_completion: true,
+  };
+
+  const response = await fetch(CLAVATA_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${CLAVATA_AUTH_TOKEN}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(
+      `Clavata API error: ${response.status} ${response.statusText} - ${errorText}`
+    );
+  }
+
+  const data: CreateJobResponse = await response.json();
+  return data.job;
+}
+
+/**
+ * Evaluates the provided text against Clavata policy and returns any matching labels.
+ *
+ * @param text - The text to evaluate.
+ * @returns A Promise resolving to an array of label names that matched.
+ * @throws An error if the evaluation fails or no results are returned.
+ */
+export async function evaluateClavataPolicy(text: string): Promise<string[]> {
+  const job = await createJob(text);
+
+  if (!job.results || job.results.length === 0) {
+    throw new Error("No results from Clavata API");
+  }
+
+  // For simplicity, use the first result's report
+  const report = job.results[0].report;
+
+  if (report.result === "OUTCOME_FAILED") {
+    throw new Error("Policy evaluation failed.");
+  }
+
+  // Extract labels from each section where the outcome is true.
+  const matchedLabels = report.sectionEvaluationReports
+    .filter((section) => section.result === "OUTCOME_TRUE")
+    .map((section) => section.name);
+
+  return matchedLabels;
+}
+
+/**
+ * A helper function to run Clavata evaluation.
+ * If labels are returned, it creates annotations using the provided label creator.
+ *
+ * @param text The text to evaluate.
+ * @param identifier The user DID or record URI to annotate.
+ * @param eventId The current event id (for logging).
+ */
+async function processClavataEvaluation(
+  text: string,
+  identifier: string,
+  eventId: number,
+  commentFn: (id: string, comment: string) => Promise<void>
+): Promise<void> {
+  try {
+    const labels = await evaluateClavataPolicy(text);
+    if (labels.length > 0) {
+      logger.info(
+        `Event ${eventId}: Clavata policy matched for ${identifier}: ${labels.join(", ")}`
+      );
+      // Create an annotation for each matched label.
+      if (labels.length > 0) {
+        const commentMessage = `Clavata evaluation identified the following labels: ${labels.join(", ")}`;
+        logger.info(
+          `Event ${eventId}: Commenting on ${identifier} with: ${commentMessage}`
+        );
+        await commentFn(identifier, commentMessage);
+      } else {
+        logger.info(`Event ${eventId}: No Clavata match for ${identifier}.`);
+      }
+    }
+  } catch (error) {
+    logger.error(
+      `Error during Clavata evaluation for ${identifier} in event ${eventId}: ${error}`
+    );
+  }
+}
+
+export { processClavataEvaluation };

--- a/src/clavataPolicy.ts
+++ b/src/clavataPolicy.ts
@@ -139,7 +139,7 @@ export async function evaluateClavataPolicy(text: string): Promise<string[]> {
  * @param identifier The user DID or record URI to annotate.
  * @param eventId The current event id (for logging).
  */
-async function processClavataEvaluation(
+export async function processClavataEvaluation(
   text: string,
   identifier: string,
   eventId: number,
@@ -168,5 +168,3 @@ async function processClavataEvaluation(
     );
   }
 }
-
-export { processClavataEvaluation };

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,3 +9,5 @@ export const LABEL_LIMIT_WAIT = process.env.LABEL_LIMIT_WAIT;
 export const AUTOACK_PERIOD = process.env.AUTOACK_PERIOD
   ? parseInt(process.env.AUTOACK_PERIOD, 10)
   : 600000;
+export const CLAVATA_AUTH_TOKEN = process.env.CLAVATA_AUTH_TOKEN ?? "";
+export const POLICY_ID = process.env.POLICY_ID ?? "";

--- a/src/getPosts.ts
+++ b/src/getPosts.ts
@@ -1,0 +1,38 @@
+import { agent, isLoggedIn } from "./agent.js";
+
+/**
+ * Retrieves the text content of a post record from its AT URI.
+ *
+ * The expected format of the URI is:
+ *   at://<DID>/<COLLECTION>/<RKEY>
+ *
+ * For post records, COLLECTION is expected to be "app.bsky.feed.post".
+ *
+ * @param uri - The AT URI of the post record.
+ * @returns The post text, or null if not found.
+ */
+export async function getPostContent(uri: string): Promise<string | null> {
+  try {
+    await isLoggedIn;
+
+    // Split the URI into its parts.
+    const parts = uri.split("/");
+    if (parts.length < 5) {
+      console.error("Invalid AT URI format:", uri);
+      return null;
+    }
+    const repo = parts[2]; // the account's DID
+    // We ignore parts[3] since it should be "app.bsky.feed.post" and getPost assumes that collection.
+    const rkey = parts.slice(4).join("/");
+
+    // Call getPost with the repo and rkey
+    const response = await agent.getPost({ repo, rkey });
+
+    // We cast value to an object that may contain a "text" field.
+    const record = response.value as { text?: string };
+    return record.text || null;
+  } catch (error) {
+    console.error(`Error fetching post content for URI ${uri}:`, error);
+    return null;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,13 @@ import { AUTOACK_PERIOD, MOD_DID } from "./config.js";
 import { IGNORED_DIDS, ReportCheck, LabelCheck } from "./constants.js";
 import { getEvents } from "./getEvents.js";
 import { ModEventView } from "@atproto/api/dist/client/types/tools/ozone/moderation/defs.js";
-import { createAccountLabel } from "./moderation.js";
+import {
+  createAccountLabel,
+  createAccountComment,
+  createPostComment,
+} from "./moderation.js";
+import { processClavataEvaluation } from "./clavataPolicy.js";
+import { getPostContent } from "./getPosts.js";
 
 let isRunning = true;
 
@@ -39,22 +45,34 @@ async function main() {
               const id = event.id;
               if (event.subject.hasOwnProperty("did")) {
                 const user = event.subject.did as string;
+                // We are erring on the side of annotating anything that is reported
+                // But this could easily be moved later if we wish to eliminate
+                // reports based on additional the simpler criteria first
+                const profile = await getProfiles(user);
+                if (profile?.description) {
+                  await processClavataEvaluation(
+                    profile.description,
+                    user,
+                    id,
+                    createAccountComment
+                  );
+                }
                 // Check if the report account is tombstoned
                 if (event.event.tombstone) {
                   logger.info(
-                    `Event ${id}: Auto-acknowledging tombstone event for ${user}`,
+                    `Event ${id}: Auto-acknowledging tombstone event for ${user}`
                   );
                   await AckReportRepo(user, event.subject.$type);
                 } else if (!event.event.tombstone) {
                   // Automatically label accounts reported automatically from the blocklist
                   if (event.createdBy === "did:plc:dbnoyyuzwgps2zr7v2psvp6o") {
                     logger.info(
-                      `Event ${id}: Labeling report for ${user} due to inclusion on imported blocklist.`,
+                      `Event ${id}: Labeling report for ${user} due to inclusion on imported blocklist.`
                     );
                     await createAccountLabel(
                       user,
                       "suspect-inauthentic",
-                      "Imported from https://bsky.app/profile/did:plc:d7nr65djxrudtdg3tslzfiyr/lists/3lcm6ypfdj72r",
+                      "Imported from https://bsky.app/profile/did:plc:d7nr65djxrudtdg3tslzfiyr/lists/3lcm6ypfdj72r"
                     );
                   } else {
                     // Check to see if an account already has a label
@@ -64,11 +82,11 @@ async function main() {
                       const value = label.val;
                       if (LabelCheck.includes(value)) {
                         logger.info(
-                          `${id}, Found ${value} on ${user}. Acknowledging.`,
+                          `${id}, Found ${value} on ${user}. Acknowledging.`
                         );
                         await AckReportRepo(
                           user,
-                          "com.atproto.admin.defs#repoRef",
+                          "com.atproto.admin.defs#repoRef"
                         );
                       }
                     }
@@ -79,7 +97,7 @@ async function main() {
                   "com.atproto.moderation.defs#reasonSexual"
                 ) {
                   logger.info(
-                    `Event ${id}: Out of scope content reported for ${user}`,
+                    `Event ${id}: Out of scope content reported for ${user}`
                   );
                   await AckReportRepo(user, event.subject.$type);
                   // Automatically acknowledge reports with comments indicating out of scope content
@@ -90,7 +108,7 @@ async function main() {
                       event.subject.$type === "com.atproto.admin.defs#repoRef"
                     ) {
                       logger.info(
-                        `Event ${id}: Comment indicates out of scope report for ${user}`,
+                        `Event ${id}: Comment indicates out of scope report for ${user}`
                       );
                       await AckReportRepo(user, event.subject.$type);
                     }
@@ -98,7 +116,7 @@ async function main() {
                 } else if (!event.event.hasOwnProperty("comment")) {
                   // Automatically acknowledge reports with no comments - these are generally useless
                   logger.info(
-                    `Event ${id}: Auto-acknowledging report for ${user} with no comment`,
+                    `Event ${id}: Auto-acknowledging report for ${user} with no comment`
                   );
                   await AckReportRepo(user, event.subject.$type);
                 } else if (IGNORED_DIDS.includes(user)) {
@@ -109,7 +127,7 @@ async function main() {
                   if (profile?.description) {
                     if (ReportCheck.test(profile.description)) {
                       logger.info(
-                        `Event ${id}: Comment indicates out of scope report for ${user}`,
+                        `Event ${id}: Comment indicates out of scope report for ${user}`
                       );
                       await AckReportRepo(user, event.subject.$type);
                     }
@@ -117,7 +135,7 @@ async function main() {
                 }
               } else {
                 logger.warn(
-                  `Event ${id}: DID expected but not found for report`,
+                  `Event ${id}: DID expected but not found for report`
                 );
               }
             }
@@ -129,9 +147,23 @@ async function main() {
                 const uri = event.subject.uri as string;
                 const cid = event.subject.cid as string;
                 const user = uri.split("/")[2];
+                // Right now have only implemented this for posts
+                // other reportable content types will need to be added
+                if (uri.split("/")[3] == "app.bsky.feed.post") {
+                  const post = await getPostContent(uri);
+                  // Like above, we are erring on the side of annotating anything that is reported
+                  if (post) {
+                    await processClavataEvaluation(
+                      post,
+                      uri,
+                      id,
+                      (uri, comment) => createPostComment(uri, cid, comment)
+                    );
+                  }
+                }
                 if (event.event.tombstone) {
                   logger.info(
-                    `Event ${id}: Auto-acknowledging tombstone event for ${uri} with CID ${cid}`,
+                    `Event ${id}: Auto-acknowledging tombstone event for ${uri} with CID ${cid}`
                   );
                   await AckReportPost(uri, cid, event.subject.$type);
                 } else if (
@@ -139,21 +171,21 @@ async function main() {
                   "com.atproto.moderation.defs#reasonSexual"
                 ) {
                   logger.info(
-                    `Event ${id}: Out of scope record reported with ${uri} with CID ${cid}`,
+                    `Event ${id}: Out of scope record reported with ${uri} with CID ${cid}`
                   );
                   await AckReportPost(uri, cid, event.subject.$type);
                 } else if (event.event.hasOwnProperty("comment")) {
                   const comment = event.event.comment as string;
                   if (ReportCheck.test(comment)) {
                     logger.info(
-                      `Event ${id}: Comment indicates out of scope record reported with ${uri} with CID ${cid}`,
+                      `Event ${id}: Comment indicates out of scope record reported with ${uri} with CID ${cid}`
                     );
                     await AckReportPost(uri, cid, event.subject.$type);
                   }
                 } else if (!event.event.hasOwnProperty("comment")) {
                   // Automatically acknowledge reports with no comments - these are generally useless
                   logger.info(
-                    `Event ${id}: Auto-acknowledging report for ${uri} with no comment`,
+                    `Event ${id}: Auto-acknowledging report for ${uri} with no comment`
                   );
                   await AckReportPost(uri, cid, event.subject.$type);
                 } else if (IGNORED_DIDS.includes(user)) {
@@ -162,7 +194,7 @@ async function main() {
                 }
               } else {
                 logger.warn(
-                  `Event ${id}: URI expected but not found for report`,
+                  `Event ${id}: URI expected but not found for report`
                 );
               }
             }
@@ -187,7 +219,7 @@ async function main() {
 
             // Fin
           }
-        }) ?? [],
+        }) ?? []
       );
     } catch (e) {
       logger.error(e);

--- a/src/moderation.ts
+++ b/src/moderation.ts
@@ -7,7 +7,7 @@ export const createPostLabel = async (
   uri: string,
   cid: string,
   label: string,
-  comment: string,
+  comment: string
 ) => {
   await isLoggedIn;
   await limit(async () => {
@@ -37,7 +37,7 @@ export const createPostLabel = async (
             "atproto-accept-labelers":
               "did:plc:ar7c4by46qjdydhdevvrndac;redact",
           },
-        },
+        }
       );
     } catch (e) {
       console.error(e);
@@ -48,7 +48,7 @@ export const createPostLabel = async (
 export const createAccountLabel = async (
   did: string,
   label: string,
-  comment: string,
+  comment: string
 ) => {
   await isLoggedIn;
   await limit(async () => {
@@ -77,7 +77,7 @@ export const createAccountLabel = async (
             "atproto-accept-labelers":
               "did:plc:ar7c4by46qjdydhdevvrndac;redact",
           },
-        },
+        }
       );
     } catch (e) {
       console.error(e);
@@ -111,7 +111,45 @@ export const createAccountComment = async (did: string, comment: string) => {
             "atproto-accept-labelers":
               "did:plc:ar7c4by46qjdydhdevvrndac;redact",
           },
+        }
+      );
+    } catch (e) {
+      console.error(e);
+    }
+  });
+};
+
+export const createPostComment = async (
+  uri: string,
+  cid: string,
+  comment: string
+) => {
+  await isLoggedIn;
+  await limit(async () => {
+    try {
+      await agent.tools.ozone.moderation.emitEvent(
+        {
+          event: {
+            $type: "tools.ozone.moderation.defs#modEventComment",
+            comment: comment,
+          },
+          // For posts, use a strongRef instead of a repoRef that requires a DID.
+          subject: {
+            $type: "com.atproto.repo.strongRef",
+            uri: uri,
+            cid: cid,
+          },
+          createdBy: `${agent.did}`,
+          createdAt: new Date().toISOString(),
         },
+        {
+          encoding: "application/json",
+          headers: {
+            "atproto-proxy": `${MOD_DID!}#atproto_labeler`,
+            "atproto-accept-labelers":
+              "did:plc:ar7c4by46qjdydhdevvrndac;redact",
+          },
+        }
       );
     } catch (e) {
       console.error(e);
@@ -146,7 +184,7 @@ export const createAccountReport = async (did: string, comment: string) => {
             "atproto-accept-labelers":
               "did:plc:ar7c4by46qjdydhdevvrndac;redact",
           },
-        },
+        }
       );
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
This runs Clavata.AI on all reported profile descriptions and post text. If the text of either of those subjects does matches, it adds a comment to the report with the matched labels. Since it did not previously exist this also added the ability to load post text.

This requires two new environment variables the ClavataJWT and policy_id.

For testing I ran the script and verified it was leaving comments on both Profiles and Posts - I saw a report of a graph.list which is not yet handled here.